### PR TITLE
同じカテゴリー名を登録する時、登録できないようにする #182

### DIFF
--- a/app/controllers/categorys_controller.rb
+++ b/app/controllers/categorys_controller.rb
@@ -14,12 +14,11 @@ class CategorysController < ApplicationController
 
 
   def create
-    binding.pry
     category = current_user.category.create(category_params)
     if category.save
       redirect_to categorys_path, notice:"作成しました"
     else
-      redirect_to new_category_path, alert: "空投稿はできません。"
+      redirect_to new_category_path, alert: "エラーが発生しました。重複・空投稿の可能性はありませんか？"
     end
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,5 +1,6 @@
 class Category < ApplicationRecord
   validates :name, presence: true, length: { maximum: 20 }
+  validates :name, :uniqueness => {:scope => :user_id}
 
   has_many :tasks, dependent: :destroy
   scope :tasks, -> { order(position: :asc)}


### PR DESCRIPTION
# 概要
- validateを作成して、同じユーザーが同じカテゴリー名を設定できないように制限をかけました #182 