### PR TITLE
participationのバリデージョンの調整 #174

### DIFF
--- a/app/controllers/categorys_controller.rb
+++ b/app/controllers/categorys_controller.rb
@@ -28,7 +28,6 @@ class CategorysController < ApplicationController
 
 
   def update
-    binding.pry
     @category.update!(category_params)
     redirect_to categorys_path, notice: "更新しました"
   end

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -13,11 +13,18 @@ class ParticipationsController < ApplicationController
   end
 
 
+
+#///////////////////////
+
   def show
     @participations = Participation.all
     @participations = @participations.where(category: params[:id])
     @participation = params[:id]
+    binding.pry
+    @user = User.find(@participations)
   end
+
+#////////////////
 
 
   def create

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -21,16 +21,20 @@ class ParticipationsController < ApplicationController
 
 
   def create
-    participation = Participation.create(
-                    owner_id: current_user[:id], 
-                    participation_id: participation_params[:participation_id],
-                    category: participation_params[:category_id],
-                    )
-    if participation.save
-      redirect_to participation_path(participation_params[:category_id]), notice:"作成しました"
-    
+    if current_user[:id] == participation_params[:participation_id].to_i
+      redirect_to new_participation_path ,alert: "自分自身は登録できません"
     else
-      redirect_to new_participation_path, alert: "入力に誤りがあります。すでに登録されている可能性もあります。"
+
+      participation = Participation.create(
+                      owner_id: current_user[:id], 
+                      participation_id: participation_params[:participation_id],
+                      category: participation_params[:category_id],
+                      )
+      if participation.save
+        redirect_to participation_path(participation_params[:category_id]), notice:"作成しました"
+      else
+        redirect_to new_participation_path, alert: "入力に誤りがあります。すでに登録されている可能性もあります。"
+      end
     end
   end
 
@@ -48,6 +52,9 @@ class ParticipationsController < ApplicationController
 
   def set_participation
     @participation = Participation.find(params[:id])
+    
+
+
     # cuurent_userのみ消せないように後から設定する
     # redirect_to category_path, alert: "権限がありません"
   end

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -21,7 +21,7 @@ class ParticipationsController < ApplicationController
     @participations = @participations.where(category: params[:id])
     @participation = params[:id]
     binding.pry
-    @user = User.find(@participations)
+    # @user = User.find(@participations)
   end
 
 #////////////////

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -57,7 +57,6 @@ class TasksController < ApplicationController
   end
 
   def move
-    binding.pry
     @task = Task.find(params[:id])
     @task.insert_at(params[:position].to_i)
     head :ok

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -69,6 +69,7 @@ class UsersController < ApplicationController
   
   def user_params
     params.require(:user).permit(:image)
+    # params.permit(:image)
   end
   
 end

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -2,4 +2,6 @@ class Participation < ApplicationRecord
   validates :owner_id, presence: true
   validates :participation_id, presence: true ,numericality: {only_integer: true}
   validates :category, presence: true, uniqueness: { scope: :participation_id }
+
+  # belongs_to :user, class_name: 'User', foreign_key: :owner_id
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
   
   has_many :category, dependent: :destroy, foreign_key: 'user_id'
   scope :category, -> { order(position: :asc)}
+  
+  # has_many :participations, foreign_key: :participation_id
 
   has_many :check, dependent: :destroy, foreign_key: 'user_id'
 

--- a/app/views/participations/new.html.erb
+++ b/app/views/participations/new.html.erb
@@ -24,9 +24,6 @@
  <% end %>
 <div>
 
-
-
-
 <div class="border mt-5 p-3">
   <h5 class="mb-3">候補ユーザ検索</h5>
   <div class="my-3">

--- a/app/views/participations/new.html.erb
+++ b/app/views/participations/new.html.erb
@@ -1,7 +1,7 @@
 <div class="card category-card">
   <div>
     <div class="text-left w-25 d-inline-block float-left ">
-      <%= link_to "キャンセル", categorys_path, class: 'text-dark'%>
+      <%= link_to "キャンセル", participation_path(params[:category]), class: 'text-dark'%>
     </div>
     <div class="w-50 d-inline-block float-left">
       <h5 class="text-center">新しいメンバーを追加する</h5>

--- a/app/views/participations/show.html.erb
+++ b/app/views/participations/show.html.erb
@@ -20,9 +20,6 @@
           <div class="text-left w-25 d-inline-block float-left ">
             <div>No.<%= i %></div>
           </div>
-  
-　　　　　　<% if @user[:id] == p.participation_id %>
-
 
           <div class="w-50 d-inline-block float-left">
             <h5 class="text-center"><%= p.participation_id%></h5>

--- a/app/views/participations/show.html.erb
+++ b/app/views/participations/show.html.erb
@@ -21,8 +21,11 @@
             <div>No.<%= i %></div>
           </div>
   
+　　　　　　<% if @user[:id] == p.participation_id %>
+
+
           <div class="w-50 d-inline-block float-left">
-            <h5 class="text-center">ここにユーザー名を表示<%= p.participation_id%></h5>
+            <h5 class="text-center"><%= p.participation_id%></h5>
           </div>
   
           <div class="w-25 d-inline-block">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -7,6 +7,7 @@
 </div>
 
 <%= form_with model: @user, local: true do |form| %>
+  <p><%= form.hidden_field :user, value: @user %></p>
   <p><%= form.file_field :image, accept: "image/png,image/jpeg,image/gif" ,class: "btn btn-primary btn-block" %></p>
   <p><%= form.submit "送信", class: "btn btn-primary btn-block"%></p>
 <% end %>

--- a/db/migrate/20201207095223_create_participations.rb
+++ b/db/migrate/20201207095223_create_participations.rb
@@ -2,10 +2,12 @@ class CreateParticipations < ActiveRecord::Migration[6.0]
   def change
     create_table :participations do |t|
       t.integer :owner_id, null: false
-      t.integer :participation_id, null: false 
+      t.integer :participation_id, null: false
+      # t.integer :participation_id, null: false, index: true 
       t.integer :category, null: false
 
       t.timestamps
     end
+    # add_foreign_key :participations, :users, column: :participation_id
   end
 end


### PR DESCRIPTION
# 概要
- participation_idにログインユーザーを登録させない #174 

# 補足
以下の項目は未達成のため、後日実装する
-  参加者の名前を表示させる
-  存在しないuser_idは登録できないようにする