### PR TITLE
Participationテーブルの修正

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,6 +137,8 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    nokogiri (1.11.1-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.20.1)
     parser (3.0.0.0)
@@ -307,6 +309,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   acts_as_list (~> 1.0)

--- a/app/assets/stylesheets/participation.scss
+++ b/app/assets/stylesheets/participation.scss
@@ -37,6 +37,7 @@
   background-color: $cWhite;
   padding: 20px 40px;
   margin: 0 auto;
+  margin-bottom: 10px;
 
 
   & .number {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,4 +22,9 @@ class ApplicationController < ActionController::Base
     redirect_back(fallback_location: root_path) and return unless user_signed_in?
     # flash[:alert] = 'ログインしてください'
   end
+
+  # リダイレクトするメソッド
+  def redirect_root
+    redirect_back(fallback_location: root_path) and return
+  end
 end

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -16,18 +16,17 @@ class ParticipationsController < ApplicationController
   # リファクタリングすること
   def show
     @participations = Participation.where(owner_id: current_user.id)
-
     # @participations = Participation.includes(owner_id: current_user.id)
     @category_id = params[:id]
   end
 
   def create
     # ログインユーザーの登録を阻止
-    redirect_to participation_path(participation_params[:owner_id]), alert: 'ログインユーザーは登録できません'
-    and return if participation_params[:user_id].to_i == current_user.id
+    # TODO: before_actionにて実装する
+    redirect_to participation_path(participation_params[:owner_id]), alert: 'ログインユーザーは登録できません' and return if participation_params[:user_id].to_i == current_user.id
     
     #同じユーザーの登録を阻止 
-    binding.pry
+    redirect_to participation_path(participation_params[:owner_id]), alert: 'すでに登録されたユーザーです' and return if Participation.exists?(user_id: participation_params[:user_id])
 
     @participation = Participation.new(participation_params)
     

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -22,16 +22,23 @@ class ParticipationsController < ApplicationController
   end
 
   def create
-    @participation = Participation.new(participation_params)
+    # ログインユーザーの登録を阻止
+    redirect_to participation_path(participation_params[:owner_id]), alert: 'ログインユーザーは登録できません'
+    and return if participation_params[:user_id].to_i == current_user.id
+    
+    #同じユーザーの登録を阻止 
+    binding.pry
 
+    @participation = Participation.new(participation_params)
+    
     if @participation.save
       redirect_to participation_path(@participation[:owner_id]), notice: '共有者を追加しました'
     else
-      # @owner_id = current_user[:id]
       @category_id = participation_params[:category_id]
+      render :new and return
+      # @owner_id = current_user[:id]
       # @q = User.ransack(params[:q])
       # @search_users = @q.result(distinct: true).limit(PER_PAGE)
-      render :new
     end
   end
 
@@ -64,4 +71,6 @@ class ParticipationsController < ApplicationController
   #     # redirect_to new_participation_path, alert: '自分自身は登録できません'
   #   end
   # end
+
+
 end

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -1,15 +1,9 @@
-# frozen_string_literal: true
-
 class ParticipationsController < ApplicationController
   before_action :login_check
   before_action :set_ransack, only: %i[new]
   before_action :participation_params, only: %i[create]
   before_action :current_user?, only: %i[create]
   before_action :set_participation, only: %i[destroy]
-
-  # テスト用
-  skip_before_action :login_check
-  skip_before_action :current_user?, only: %i[create]
 
   PER_PAGE = 3
 

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -1,9 +1,9 @@
 class ParticipationsController < ApplicationController
   before_action :login_check
-  # before_action :set_ransack, only: %i[new]
-  before_action :participation_params, only: %i[create]
-  before_action :current_user?, only: %i[create]
   before_action :set_participation, only: %i[destroy]
+  # before_action :set_ransack, only: %i[new]
+  # 登録しようとしているユーザーがログインユーザーではないか？
+  # before_action :current_user?, only: %i[create]
 
   PER_PAGE = 3
 
@@ -13,19 +13,22 @@ class ParticipationsController < ApplicationController
     @category_id = params[:format]
   end
 
+  # リファクタリングすること
   def show
-    @participations = Participation.order(id: :asc)
-    @participations = @participations.where(category_id: params[:id])
+    binding.pry
+    @participations = Participation.where(owner_id: current_user.id)
+
+    # @participations = Participation.includes(owner_id: current_user.id)
     @category_id = params[:id]
   end
 
   def create
-    binding.pry
     @participation = Participation.new(participation_params)
 
     if @participation.save
-      redirect_to participation_path(category_id), notice: '作成しました'
+      redirect_to participation_path(@participation[:owner_id]), notice: '共有者を追加しました'
     else
+      binding.pry
       # @owner_id = current_user[:id]
       @category_id = participation_params[:category_id]
       # @q = User.ransack(params[:q])
@@ -51,14 +54,16 @@ class ParticipationsController < ApplicationController
     # redirect_to category_path, alert: "権限がありません"
   end
 
-  def set_ransack
-    @q = User.ransack(params[:q])
-    @search_users = @q.result(distinct: true).limit(PER_PAGE)
-  end
+  # def set_ransack
+  #   @q = User.ransack(params[:q])
+  #   @search_users = @q.result(distinct: true).limit(PER_PAGE)
+  # end
 
-  def current_user?
-    if current_user[:id] == participation_params[:user_id].to_i
-      redirect_to new_participation_path, alert: '自分自身は登録できません'
-    end
-  end
+  # def current_user?
+  #   binding.pry
+  #   if current_user[:id] == participation_params[:user_id].to_i
+  #     render :new, alert: '自分自身は登録できません'
+  #     # redirect_to new_participation_path, alert: '自分自身は登録できません'
+  #   end
+  # end
 end

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -15,7 +15,6 @@ class ParticipationsController < ApplicationController
 
   # リファクタリングすること
   def show
-    binding.pry
     @participations = Participation.where(owner_id: current_user.id)
 
     # @participations = Participation.includes(owner_id: current_user.id)
@@ -28,7 +27,6 @@ class ParticipationsController < ApplicationController
     if @participation.save
       redirect_to participation_path(@participation[:owner_id]), notice: '共有者を追加しました'
     else
-      binding.pry
       # @owner_id = current_user[:id]
       @category_id = participation_params[:category_id]
       # @q = User.ransack(params[:q])

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -1,6 +1,7 @@
 class ParticipationsController < ApplicationController
   before_action :login_check
   before_action :set_participation, only: %i[destroy]
+  before_action :present_participation_user?, only: %i[create]
   # before_action :set_ransack, only: %i[new]
   # 登録しようとしているユーザーがログインユーザーではないか？
   # before_action :current_user?, only: %i[create]
@@ -13,28 +14,21 @@ class ParticipationsController < ApplicationController
     @category_id = params[:format]
   end
 
-  # リファクタリングすること
   def show
+    # TODO: N+１問題を解消すること
     @participations = Participation.where(owner_id: current_user.id)
-    # @participations = Participation.includes(owner_id: current_user.id)
     @category_id = params[:id]
   end
 
   def create
-    # ログインユーザーの登録を阻止
-    # TODO: before_actionにて実装する
-    redirect_to participation_path(participation_params[:owner_id]), alert: 'ログインユーザーは登録できません' and return if participation_params[:user_id].to_i == current_user.id
-    
-    #同じユーザーの登録を阻止 
-    redirect_to participation_path(participation_params[:owner_id]), alert: 'すでに登録されたユーザーです' and return if Participation.exists?(user_id: participation_params[:user_id])
+    present_participation_user?
 
     @participation = Participation.new(participation_params)
-    
     if @participation.save
       redirect_to participation_path(@participation[:owner_id]), notice: '共有者を追加しました'
     else
       @category_id = participation_params[:category_id]
-      render :new and return
+      render :new
       # @owner_id = current_user[:id]
       # @q = User.ransack(params[:q])
       # @search_users = @q.result(distinct: true).limit(PER_PAGE)
@@ -54,8 +48,6 @@ class ParticipationsController < ApplicationController
 
   def set_participation
     @participation = Participation.find(params[:id])
-    # cuurent_userのみ消せないように後から設定する
-    # redirect_to category_path, alert: "権限がありません"
   end
 
   # def set_ransack
@@ -63,13 +55,10 @@ class ParticipationsController < ApplicationController
   #   @search_users = @q.result(distinct: true).limit(PER_PAGE)
   # end
 
-  # def current_user?
-  #   binding.pry
-  #   if current_user[:id] == participation_params[:user_id].to_i
-  #     render :new, alert: '自分自身は登録できません'
-  #     # redirect_to new_participation_path, alert: '自分自身は登録できません'
-  #   end
-  # end
-
-
+  def present_participation_user?
+    # ログインユーザーのチェック
+    redirect_to participation_path(participation_params[:owner_id]), alert: 'ログインユーザーは登録できません' and return if participation_params[:user_id].to_i == current_user.id
+    # 同じユーザーの登録を阻止 
+    redirect_to participation_path(participation_params[:owner_id]), alert: 'すでに登録されたユーザーです' and return if Participation.exists?(user_id: participation_params[:user_id])
+  end
 end

--- a/app/controllers/participations_controller.rb
+++ b/app/controllers/participations_controller.rb
@@ -1,15 +1,15 @@
 class ParticipationsController < ApplicationController
   before_action :login_check
-  before_action :set_ransack, only: %i[new]
+  # before_action :set_ransack, only: %i[new]
   before_action :participation_params, only: %i[create]
   before_action :current_user?, only: %i[create]
   before_action :set_participation, only: %i[destroy]
 
   PER_PAGE = 3
 
+  # OK
   def new
     @participation = Participation.new
-    @owner_id = current_user[:id]
     @category_id = params[:format]
   end
 
@@ -20,15 +20,16 @@ class ParticipationsController < ApplicationController
   end
 
   def create
+    binding.pry
     @participation = Participation.new(participation_params)
 
     if @participation.save
       redirect_to participation_path(category_id), notice: '作成しました'
     else
-      @owner_id = current_user[:id]
+      # @owner_id = current_user[:id]
       @category_id = participation_params[:category_id]
-      @q = User.ransack(params[:q])
-      @search_users = @q.result(distinct: true).limit(PER_PAGE)
+      # @q = User.ransack(params[:q])
+      # @search_users = @q.result(distinct: true).limit(PER_PAGE)
       render :new
     end
   end
@@ -41,7 +42,7 @@ class ParticipationsController < ApplicationController
   private
 
   def participation_params
-    params.require(:participation).permit(:owner_id, :user_id, :category_id)
+    params.require(:participation).permit(:owner_id, :user_id, :category_id).merge(owner_id: current_user.id)
   end
 
   def set_participation

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,12 +1,10 @@
 class Category < ApplicationRecord
+  validates :name, presence: true, length: { maximum: 20 }
+  # validates :name, :uniqueness => {:scope => :user_id}
+  
   belongs_to :user
   acts_as_list scope: :user
-
-  validates :name, presence: true
-  validates :name, length: { maximum: 20 }
-
-  # validates :name, :uniqueness => {:scope => :user_id}
-
+  
   has_many :tasks, dependent: :destroy
   scope :tasks, -> { order(position: :asc) }
 

--- a/app/models/participation.rb
+++ b/app/models/participation.rb
@@ -2,8 +2,8 @@
 
 class Participation < ApplicationRecord
   validates :owner_id, presence: true
-  validates :user_id, presence: true
-  validates :category, presence: true, uniqueness: { scope: :user_id }
+  validates :user_id, presence: true #,uniqueness: { scope: :user_id }
+  validates :category, presence: true
 
   #  validates :participation_id, presence: true ,numericality: {only_integer: true}
   # validates :category, presence: true, uniqueness: { scope: :participation_id }

--- a/app/views/participations/_participation_card.html.erb
+++ b/app/views/participations/_participation_card.html.erb
@@ -1,12 +1,10 @@
- <% @participations.each do |participation| %>
-<% binding.pry %>
+<% @participations.each do |participation| %>
   <div class="participation__card">
-    <div class="number"><span>No.<%#= i %></span></div>
-    <div class="user__name"><span>id:<%= participation.user.id%>:<%= p.user.name%></span></div>
-    <div class="delete__btn">
-      <%= link_to participation_path(participation), class: "text-danger", data: { confirm: '本当に削除しますか?' } ,:method => :delete do %>
-        <i class="fas fa-trash"></i> 
-      <% end %>
-    </div>
-  <div>
-  <% end %>
+    <span class="number"><span>No.<%#= i %></span></span>
+    <span class="user__name"><span>id:<%= participation.user.id%>:<%= participation.user.name%></span></span>
+    <span class="delete__btn"></span>
+    <%= link_to participation_path(participation.id), class: "text-danger", data: { confirm: '本当に削除しますか?' } ,:method => :delete do %>
+      <i class="fas fa-trash"></i> 
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/participations/_participation_card.html.erb
+++ b/app/views/participations/_participation_card.html.erb
@@ -1,0 +1,12 @@
+ <% @participations.each do |participation| %>
+<% binding.pry %>
+  <div class="participation__card">
+    <div class="number"><span>No.<%#= i %></span></div>
+    <div class="user__name"><span>id:<%= participation.user.id%>:<%= p.user.name%></span></div>
+    <div class="delete__btn">
+      <%= link_to participation_path(participation), class: "text-danger", data: { confirm: '本当に削除しますか?' } ,:method => :delete do %>
+        <i class="fas fa-trash"></i> 
+      <% end %>
+    </div>
+  <div>
+  <% end %>

--- a/app/views/participations/_search_form.html.erb
+++ b/app/views/participations/_search_form.html.erb
@@ -1,0 +1,19 @@
+<div class="border mt-5 p-3 bg-white">
+  <h5 class="mb-3">候補ユーザ検索</h5>
+  <div class="my-3">
+    <%= search_form_for @q , url: new_participation_path do |f| %>
+      <%= f.label :name_cont, "ユーザー名" %>
+      <%= f.search_field :name_cont %>
+      <%= f.submit "検索", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+
+  <div class="p-3 mt-5">
+    <% @search_users.each.with_index(1) do |user,i| %>
+      <div class=" mb-3 ">
+        <span class="mr-5 ">No.<%= i %></span>
+        <span><%= user.name %> ID:【<%= user.id %>】</span>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/participations/new.html.erb
+++ b/app/views/participations/new.html.erb
@@ -22,22 +22,6 @@
  <% end %>
 </section>
 
-<div class="border mt-5 p-3 bg-white">
-  <h5 class="mb-3">候補ユーザ検索</h5>
-  <div class="my-3">
-    <%= search_form_for @q , url: new_participation_path do |f| %>
-      <%= f.label :name_cont, "ユーザー名" %>
-      <%= f.search_field :name_cont %>
-      <%= f.submit "検索", class: "btn btn-primary" %>
-    <% end %>
-  </div>
 
-  <div class="p-3 mt-5">
-    <% @search_users.each.with_index(1) do |user,i| %>
-      <div class=" mb-3 ">
-        <span class="mr-5 ">No.<%= i %></span>
-        <span><%= user.name %> ID:【<%= user.id %>】</span>
-      </div>
-    <% end %>
-  </div>
-</div>
+<!-- 検索フォーム -->
+<%#= render partial: 'search_form'%>

--- a/app/views/participations/new.html.erb
+++ b/app/views/participations/new.html.erb
@@ -12,12 +12,18 @@
   <%= render 'layouts/error_form',  model: @participation %>
 
   <%= form_with model: @participation, local: true do |f| %>
-      <p><%= f.number_field :user_id , class: "form__submit"%></p> 
-      <%= f.hidden_field :category_id , value: @category_id %>
+    <p><%= f.hidden_field :owner_id , class: "form__submit", value: current_user.id %></p> 
+    
+    <div class="form__submit">
+      <p>ログインユーザー：<%= current_user.name %></p>
+      <p>id：<%= current_user.id %></p> 
+    </div>
+    <p><%= f.number_field :user_id , class: "form__submit" %></p> 
+    <%= f.hidden_field :category_id , value: @category_id %>
 
-      <section id="participation-btn">
-        <%= f.submit "作成", class:"btn float-purple"%>
-      </section>
+    <section id="participation-btn">
+      <%= f.submit "作成", class:"btn float-purple"%>
+    </section>
  <% end %>
 </section>
 

--- a/app/views/participations/new.html.erb
+++ b/app/views/participations/new.html.erb
@@ -12,13 +12,12 @@
   <%= render 'layouts/error_form',  model: @participation %>
 
   <%= form_with model: @participation, local: true do |f| %>
-      <%= f.hidden_field :owner_id , value: @owner_id %>
       <p><%= f.number_field :user_id , class: "form__submit"%></p> 
       <%= f.hidden_field :category_id , value: @category_id %>
 
-    <section id="participation-btn">
+      <section id="participation-btn">
         <%= f.submit "作成", class:"btn float-purple"%>
-    </section>
+      </section>
  <% end %>
 </section>
 

--- a/app/views/participations/new.html.erb
+++ b/app/views/participations/new.html.erb
@@ -6,14 +6,14 @@
 
 <section class="form">
   <div class="form__title">
-  <p>参加者ID</p>
+    <p>参加者ID</p>
   </div>
 
   <%= render 'layouts/error_form',  model: @participation %>
 
   <%= form_with model: @participation, local: true do |f| %>
       <%= f.hidden_field :owner_id , value: @owner_id %>
-      <p><%= f.text_field :user_id , size: 2, class: "form__submit"%></p> 
+      <p><%= f.number_field :user_id , class: "form__submit"%></p> 
       <%= f.hidden_field :category_id , value: @category_id %>
 
     <section id="participation-btn">

--- a/app/views/participations/show.html.erb
+++ b/app/views/participations/show.html.erb
@@ -7,24 +7,8 @@
   <% end %>
 </div>
 
-<% binding.pry%>
 <% if @participations.empty? %>
   <p class="no__data__card">現在共有しているユーザーはいません</p>
 <% else %>
- 
-  <%#= render partial: 'participation_card', locals: { participations: @participations }%>
-  
-<% @participations.each do |participation| %>
- 
-  <div class="participation__card">
-    <span class="number"><span>No.<%#= i %></span></span>
-    <span class="user__name"><span>id:<%= participation.user.id%>:<%= participation.user.name%></span></span>
-    <span class="delete__btn">
-      <%= link_to participation_path(participation.id), class: "text-danger", data: { confirm: '本当に削除しますか?' } ,:method => :delete do %>
-        <i class="fas fa-trash"></i> 
-      <% end %>
-    </span>
-  <div>
-  <% end %>
-
+  <%= render partial: 'participation_card'%> 
 <% end %>

--- a/app/views/participations/show.html.erb
+++ b/app/views/participations/show.html.erb
@@ -1,30 +1,30 @@
 <h1 class="main__title">参加者一覧</h1>
 
 <div class="page__link">
-   <%# 追加ボタン %>
-    <%= link_to new_participation_path(@category_id),class:"page__link__style", :method => :get do %> 
-      <span>共有者を追加</span><i class="fas fa-plus-circle"></i>
-    <% end %>
+  <%# 追加ボタン %>
+  <%= link_to new_participation_path(@category_id),class:"page__link__style", :method => :get do %> 
+    <span>共有者を追加</span><i class="fas fa-plus-circle"></i>
+  <% end %>
 </div>
 
+<% binding.pry%>
 <% if @participations.empty? %>
   <p class="no__data__card">現在共有しているユーザーはいません</p>
 <% else %>
+ 
+  <%#= render partial: 'participation_card', locals: { participations: @participations }%>
+  
+<% @participations.each do |participation| %>
+ 
+  <div class="participation__card">
+    <span class="number"><span>No.<%#= i %></span></span>
+    <span class="user__name"><span>id:<%= participation.user.id%>:<%= participation.user.name%></span></span>
+    <span class="delete__btn">
+      <%= link_to participation_path(participation.id), class: "text-danger", data: { confirm: '本当に削除しますか?' } ,:method => :delete do %>
+        <i class="fas fa-trash"></i> 
+      <% end %>
+    </span>
   <div>
-    <% @participations.each.with_index(1) do |p, i| %>
-      <div class="participation__card">
-          <div class="number">
-            <div>No.<%= i %></div>
-          </div>
-          <div class="user__name">
-            <div><%= p.user.name%></div>
-          </div>
-          <div class="delete__btn">
-              <%= link_to participation_path(p), class: "text-danger", data: { confirm: '本当に削除しますか?' } ,:method => :delete do %>
-                <i class="fas fa-trash"></i> 
-              <% end %>
-          </div>
-        <div>
-    <% end %>
-  </div>
+  <% end %>
+
 <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,21 +1,60 @@
-# frozen_string_literal: true
-# # テストユーザー
-# NAME = "テスト"
-# EMAIL = "test@example.com"
-# PASSWORD = "password"
+puts "テストデータのインポート開始"
+sample_user = User.where(email: "user1@example.com")
+sample_category = Category.where(user_id: sample_user)
+sample_task = Task.where(category_id: sample_category)
 
-# # データを全削除
-# User.destroy_all
-# Category.destroy_all
-# Task.destroy_all
+# User
+20.times do |i|
+  id = i + 1
+  User.find_or_create_by!(email: "user#{id}@example.com") do |u|
+    u.email = "user#{id}@example.com"
+    u.password = "password"
+    u.name = Faker::Name.name
+  end
+end
+puts "ユーザーのテストデータを作成しました"
 
-# user1 = User.create!(name: "佐藤", email: "satou@example.com", password: "password")
-# user2 = User.create!(name: "山田", email: "yamada@example.com", password: "password")
-# user3 = User.create!(name: "鈴木", email: "suzuki@example.com", password: "password")
+# Category
+sample_user.each do |user|
+  5.times do |i|
+    num = i + 1
+    user.categories.find_or_create_by!(name: "カテゴリー#{num}") do |c|
+      c.name = "カテゴリー#{num}"
+    end
+  end
+end
+puts "カテゴリーを作成しました"
 
-# Category.create!(name:"朝ルーティン", user_id: user1.id)
+# Task
+sample_category.each do |category|
+  5.times do |i|
+    num = i + 1
+    category.tasks.find_or_create_by!(name: "タスク#{num}") do |t|
+      t.name = "タスク#{num}"
+    end
+  end
+end
+puts "タスクを作成しました"
 
-# # ログイン時に使用するアカウント（変数への代入は不要）
-# User.create!(name: NAME, email: EMAIL, password: PASSWORD)
+# Participation
+sample_category.each do |category|
+  category.participations.find_or_create_by!(user_id: 2) do |p|
+    p.owner_id = category.user.id
+    p.user_id = 2
+  end
+end
+puts "共有者を追加しました"
 
-# puts "初期データの投入に成功しました！"
+# Comment
+sample_task.each do |task|
+  3.times do |i|
+    num = i + 1
+    task.comments.find_or_create_by!(content: "コメント#{num}") do |c|
+      c.user_id = task.category.user.id
+      c.content = "コメント#{num}"
+    end
+  end
+end
+puts "コメントを追加しました"
+
+puts "テストデータのインポート終了"

--- a/spec/requests/comment_request_spec.rb
+++ b/spec/requests/comment_request_spec.rb
@@ -50,7 +50,6 @@ RSpec.describe 'Comments', type: :request do
         # TODO : うまくいかない・・・
         xit 'コメントが保存される',type: :doing  do
           sign_in @user
-          binding.pry
           subject
           expect { subject }.to change { Comment.count }.by(1)
         end
@@ -107,7 +106,6 @@ RSpec.describe 'Comments', type: :request do
   
         xit 'contentが表示される' do
           subject
-          binding.pry
           expect(response.body).to include comment.content
         end
       end


### PR DESCRIPTION
# 概要
- 検索フォームを部分テンプレート化
- 入力フォームを数値に限定
- seeds.rbを改善
- カードを部分テンプレート化
- 以下２つをbefore_actionにて実装
- 共有者にログインユーザーを登録できないように制限
- 同じ共有者を登録できないメソッドを実装
